### PR TITLE
Set disable_on_destroy=true for API management.

### DIFF
--- a/modules/gke-network/main.tf
+++ b/modules/gke-network/main.tf
@@ -5,7 +5,7 @@
 resource "google_project_service" "services" {
   count = "${length(var.project_services)}"
 
-  disable_on_destroy = false
+  disable_on_destroy = true
 
   service = "${element(var.project_services, count.index)}"
 


### PR DESCRIPTION
Without this, API management code fails after up/down/up.

My PR against upstream has more details about why I did this:
https://github.com/exekube/exekube/pull/91