### PR TITLE
Add release_values_rendered to helm-release module

### DIFF
--- a/modules/helm-release/main.tf
+++ b/modules/helm-release/main.tf
@@ -29,6 +29,7 @@ resource "helm_release" "release" {
   namespace = "${var.release_namespace}"
 
   values = [
+    "${var.release_values_rendered}",
     "${data.template_file.release_values.rendered}",
     "${var.extra_values == "" ? "" : file(coalesce(var.extra_values,"/dev/null"))}",
   ]
@@ -43,7 +44,7 @@ resource "helm_release" "release" {
 
 # Parsed (interpolated) YAML values file
 data "template_file" "release_values" {
-  template = "${file("${var.release_values}")}"
+  template = "${var.release_values == "" ? "" : file(coalesce(var.release_values,"/dev/null"))}"
 
   vars {
     project_id         = "${var.project_id}"

--- a/modules/helm-release/variables.tf
+++ b/modules/helm-release/variables.tf
@@ -47,6 +47,11 @@ variable "chart_version" {
   default     = ""
 }
 
+variable "release_values_rendered" {
+  description = "Provide rendered template with release values"
+  default     = ""
+}
+
 variable "release_values" {
   description = "Specify path to release values, relative to module's path"
   default     = "values.yaml"


### PR DESCRIPTION
Right now the only way to pass release values to `helm-release` module is by providing `release_values.yaml` file, which is not very convenient or secure. This adds functionality for `helm-release` module to accept pre-rendered data via `release_values_rendered` variable.

I double checked and this does not break existing functionality of the module.