### PR TITLE
[GPII-3251]: Idempotence for helm-release destroy

### DIFF
--- a/modules/helm-release/main.tf
+++ b/modules/helm-release/main.tf
@@ -6,9 +6,9 @@ data "external" "client_auth" {
   program = [
     "sh", "-c",
     <<EOF
-      ca_cert=$(cat ${var.client_auth}/ca.cert.pem 2>/dev/null | awk '$1=$1' ORS='  \n')
-      helm_cert=$(cat ${var.client_auth}/helm.cert.pem 2>/dev/null | awk '$1=$1' ORS='  \n')
-      helm_key=$(cat ${var.client_auth}/helm.key.pem 2>/dev/null | awk '$1=$1' ORS='  \n')
+      ca_cert=$(cat ${var.client_auth}/ca.cert.pem 2>/dev/null)
+      helm_cert=$(cat ${var.client_auth}/helm.cert.pem 2>/dev/null)
+      helm_key=$(cat ${var.client_auth}/helm.key.pem 2>/dev/null)
       jq -n \
         --arg ca_cert "$ca_cert" \
         --arg helm_cert "$helm_cert" \

--- a/modules/helm-release/main.tf
+++ b/modules/helm-release/main.tf
@@ -2,6 +2,10 @@
 # PROVIDER
 # ------------------------------------------------------------------------------
 
+# Following code loads Helm certificates from files into Terraform data object.
+# In case there are no certificate files, data will be populated with empty values
+# so provider configuration can still be successful.
+# This helps to achieve idempotence for destroy operation.
 data "external" "client_auth" {
   program = [
     "sh", "-c",


### PR DESCRIPTION
I know, it looks like a really complicated fix for such a trivial issue, but believe me, there is no better way :)

Terraform will always fail during Helm provider configuration (which happens during `:destroy` as well) if certificate files not present on disk (already removed during previous `:destroy`) with:
```
Error: module.gpii-flowmanager.provider.helm: file: open /project/live/dev/secrets/kube-system/helm-tls/ca.cert.pem: no such file or directory in:

${file("${var.client_auth}/ca.cert.pem")}
```
And there is no way to evaluate if local file is present on disk in Terraform: https://github.com/hashicorp/terraform/issues/10878.