### PR TITLE
[GPII-2955, GPII-2954]: Make monitoring_service, logging_service customizable for gke-cluster

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -54,7 +54,7 @@ resource "google_container_cluster" "cluster" {
   }
 
   monitoring_service = "${var.monitoring_service}"
-  logging_service = "${var.logging_service}"
+  logging_service    = "${var.logging_service}"
 
   maintenance_policy {
     daily_maintenance_window {

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -53,6 +53,9 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
+  monitoring_service = "${var.monitoring_service}"
+  logging_service = "${var.logging_service}"
+
   maintenance_policy {
     daily_maintenance_window {
       start_time = "03:00"

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -60,3 +60,11 @@ variable "initial_node_count" {
 variable "kubernetes_version" {
   default = "1.10.5-gke.0"
 }
+
+variable "monitoring_service" {
+  default = "monitoring.googleapis.com"
+}
+
+variable "logging_service" {
+  default = "logging.googleapis.com"
+}


### PR DESCRIPTION
I am exploring monitoring/logging options:
https://cloud.google.com/monitoring/kubernetes-engine/

This is required to enable beta APIs: `monitoring.googleapis.com/kubernetes`, `logging.googleapis.com/kubernetes`.
