### PR TITLE
GPII-3339: Add disable_dashboard parameter

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -41,7 +41,7 @@ resource "google_container_cluster" "cluster" {
     }
 
     kubernetes_dashboard {
-      disabled = false
+      disabled = "${var.dashboard_disabled}"
     }
 
     http_load_balancing {

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -68,3 +68,8 @@ variable "monitoring_service" {
 variable "logging_service" {
   default = "logging.googleapis.com"
 }
+
+variable "dashboard_disabled" {
+  default = false
+  description = "Disable Kubernetes Dashboard"
+}


### PR DESCRIPTION
Kubernetes Dashboad has been deprecated on GKE (see
https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards) for
details. This adds parameter disable_dashboard to gke-cluster module.

Default (false) will keep current behaviour (Dashboard enabled).

_(Jira ticket is not referenced in the commit message as I want to open PR against upstream once reviewed)_