### PR TITLE
Only publish builds from master.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,4 +12,4 @@ push:
   script:
     - docker push gpii/exekube:0.4.0-google
   only:
-    - master@gpii-ops/gpii-infra
+    - master@gpii-ops/exekube

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,3 +11,5 @@ push:
   stage: push
   script:
     - docker push gpii/exekube:0.4.0-google
+  only:
+    - master@gpii-ops/gpii-infra


### PR DESCRIPTION
Prevent situation like last night where I messed up exekube by pushing a branch to the gpii-ops repo.