### PR TITLE
GPII-3391: Parametrise force_update of helm_release

### DIFF
--- a/modules/helm-release/main.tf
+++ b/modules/helm-release/main.tf
@@ -57,7 +57,7 @@ resource "helm_release" "release" {
     "${var.extra_values == "" ? "" : file(coalesce(var.extra_values,"/dev/null"))}",
   ]
 
-  force_update     = false
+  force_update     = "${var.force_update}"
   devel            = true
   disable_webhooks = false
   timeout          = 500

--- a/modules/helm-release/variables.tf
+++ b/modules/helm-release/variables.tf
@@ -84,3 +84,8 @@ variable "ingress_basic_auth" {
     password    = ""
   }
 }
+
+variable "force_update" {
+  description = "Force resource update through delete/recreate if needed"
+  default     = false
+}


### PR DESCRIPTION
This PR makes `force_update` on `helm_release` resource parametrised.

Pre-req for [GPII-3391](https://issues.gpii.net/secure/RapidBoard.jspa?rapidView=21&view=detail&selectedIssue=GPII-3391)

Plan to open PR against upstream once reviewed and add a link here.