### PR TITLE
GPII-3324: some export things I messed up (exekube)

### DIFF
--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -19,7 +19,7 @@ provider "google" {
 resource "google_storage_bucket" "exported-logs" {
   count         = "${var.exported_logs_encryption_key == "" ? 1 : 0}"
   name          = "${var.project_id}-exported-logs"
-  force_destroy = true
+  force_destroy = "${var.exported_logs_force_destroy}"
   storage_class = "${var.exported_logs_storage_class}"
   location      = "${var.exported_logs_storage_region}"
 
@@ -41,7 +41,7 @@ resource "google_storage_bucket" "exported-logs" {
 resource "google_storage_bucket" "exported-logs-custom-encryption" {
   count         = "${var.exported_logs_encryption_key == "" ? 0 : 1}"
   name          = "${var.project_id}-exported-logs"
-  force_destroy = true
+  force_destroy = "${var.exported_logs_force_destroy}"
   storage_class = "${var.exported_logs_storage_class}"
   location      = "${var.exported_logs_storage_region}"
 

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -115,7 +115,7 @@ resource "google_logging_project_sink" "my-export-custom-encryption" {
 # the bucket.
 resource "google_project_iam_binding" "exported-logs-writer" {
   count = "${var.exported_logs_encryption_key == "" ? 1 : 0}"
-  role = "roles/storage.objectCreator"
+  role  = "roles/storage.objectCreator"
 
   members = [
     "${google_logging_project_sink.my-export.*.writer_identity}",
@@ -124,7 +124,7 @@ resource "google_project_iam_binding" "exported-logs-writer" {
 
 resource "google_project_iam_binding" "exported-logs-writer-custom-encryption" {
   count = "${var.exported_logs_encryption_key == "" ? 0 : 1}"
-  role = "roles/storage.objectCreator"
+  role  = "roles/storage.objectCreator"
 
   members = [
     "${google_logging_project_sink.my-export-custom-encryption.*.writer_identity}",

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -114,9 +114,19 @@ resource "google_logging_project_sink" "my-export-custom-encryption" {
 # Because our sink uses a unique_writer, we must grant that writer access to
 # the bucket.
 resource "google_project_iam_binding" "exported-logs-writer" {
+  count = "${var.exported_logs_encryption_key == "" ? 1 : 0}"
   role = "roles/storage.objectCreator"
 
   members = [
     "${google_logging_project_sink.my-export.*.writer_identity}",
+  ]
+}
+
+resource "google_project_iam_binding" "exported-logs-writer-custom-encryption" {
+  count = "${var.exported_logs_encryption_key == "" ? 0 : 1}"
+  role = "roles/storage.objectCreator"
+
+  members = [
+    "${google_logging_project_sink.my-export-custom-encryption.*.writer_identity}",
   ]
 }

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -21,6 +21,10 @@ variable "exports" {
   default = {}
 }
 
+variable "exported_logs_force_destroy" {
+  default = "true"
+}
+
 variable "exported_logs_storage_class" {
   default = "REGIONAL"
 }

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -22,19 +22,23 @@ variable "exports" {
 }
 
 variable "exported_logs_force_destroy" {
-  default = "true"
+  description = "If 'true', the exported logs bucket will be destroyed on 'terragrunt destroy' or (NOTE!) on certain kinds of reconfiguration, e.g. changing storage class from REGIONAL to NEARLINE. Use caution when setting to 'true'."
+  default     = "false"
 }
 
 variable "exported_logs_storage_class" {
-  default = "REGIONAL"
+  description = "Storage class for bucket containing exported logs."
+  default     = "REGIONAL"
 }
 
 variable "exported_logs_storage_region" {
-  default = "europe-north1-a"
+  description = "Region for bucket containing exported logs."
+  default     = "europe-north1-a"
 }
 
 variable "exported_logs_expire_after" {
-  default = "14"
+  description = "Exported logs are deleted from the bucket after this many days."
+  default     = "14"
 }
 
 variable "exported_logs_encryption_key" {


### PR DESCRIPTION
Related to XXX.

1. I missed adding a separate resource for `google_project_iam_binding` when custom encryption is enabled. This was causing Terraform to remove even manually-added permissions for the bucket.

2. Add support for force_destroy. I decided we'd better have this since operations that don't necessarily look destructive (e.g. changing storage class from REGIONAL to NEARLINE) cause Terraform to destroy and re-create the bucket.

3. I tried to switch from Project-level IAM bindings to Bucket-level IAM bindings but it doesn't appear to be working (exported logs aren't written and unique writer SAs don't appear in IAM dashboard).
