### PR TITLE
[GPII-3507]: Install google-cloud-logging gem

### DIFF
--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -50,7 +50,7 @@ RUN apk --no-cache add \
         g++ \
         make \
         ruby-dev && \
-    gem install --no-ri --no-rdoc rake google-cloud-monitoring && \
+    gem install --no-ri --no-rdoc rake google-cloud-monitoring google-cloud-logging && \
     apk del \
         g++ \
         make \


### PR DESCRIPTION
Required for https://github.com/gpii-ops/gpii-infra/pull/219.