### PR TITLE
GPII-3525: Use gpii-ops build of Helm provider

### DIFF
--- a/dockerfiles/alicloud/Dockerfile
+++ b/dockerfiles/alicloud/Dockerfile
@@ -23,7 +23,7 @@ ENV HELM_VERSION 2.8.2
 ENV KUBECTL_VERSION 1.9.3
 ENV TERRAFORM_VERSION 0.11.5
 ENV TERRAGRUNT_VERSION 0.14.6
-ENV TERRAFORM_PROVIDER_HELM_VERSION 0.6.0
+ENV TERRAFORM_PROVIDER_HELM_VERSION 0.6.2
 ENV TERRAFORM_PROVIDER_ALICLOUD_VERSION 1.9.1
 
 RUN apk --no-cache add \
@@ -80,11 +80,10 @@ RUN curl -L -o ./terragrunt \
         && mv terragrunt /usr/bin
 
 RUN curl -L -o ./tph.tar.gz \
-        https://github.com/mcuadros/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
+        https://github.com/gpii-ops/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
         && tar -xvzf tph.tar.gz \
         && rm -f tph.tar.gz \
         && cd terraform-provider-helm_linux_amd64 \
-        && mv terraform-provider-helm terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
         && chmod 0700 terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
         && mkdir -p /root/.terraform.d/plugins/ \
         && mv terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} /root/.terraform.d/plugins/

--- a/dockerfiles/aws/Dockerfile
+++ b/dockerfiles/aws/Dockerfile
@@ -29,7 +29,7 @@ ENV KUBECTL_VERSION 1.10.5
 ENV HELM_VERSION 2.9.1
 ENV TERRAFORM_VERSION 0.11.7
 ENV TERRAGRUNT_VERSION 0.14.10
-ENV TERRAFORM_PROVIDER_HELM_VERSION 0.6.0
+ENV TERRAFORM_PROVIDER_HELM_VERSION 0.6.2
 
 RUN apk --no-cache add \
         curl \
@@ -80,11 +80,10 @@ RUN curl -L -o ./terragrunt \
         && mv terragrunt /usr/bin
 
 RUN curl -L -o ./tph.tar.gz \
-        https://github.com/mcuadros/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
+        https://github.com/gpii-ops/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
         && tar -xvzf tph.tar.gz \
         && rm -rf tph.tar.gz \
         && cd terraform-provider-helm_linux_amd64 \
-        && mv terraform-provider-helm terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
         && chmod 0700 terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
         && mkdir -p /root/.terraform.d/plugins/ \
         && mv terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} /root/.terraform.d/plugins/

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -27,7 +27,7 @@ ENV KUBECTL_VERSION 1.10.5
 ENV HELM_VERSION 2.9.1
 ENV TERRAFORM_VERSION 0.11.7
 ENV TERRAGRUNT_VERSION 0.14.10
-ENV TERRAFORM_PROVIDER_HELM_VERSION 0.6.0
+ENV TERRAFORM_PROVIDER_HELM_VERSION 0.6.2
 
 RUN apk --no-cache add \
         curl \
@@ -92,11 +92,10 @@ RUN curl -L -o ./terragrunt \
         && mv terragrunt /usr/bin
 
 RUN curl -L -o ./tph.tar.gz \
-        https://github.com/mcuadros/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
+        https://github.com/gpii-ops/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
         && tar -xvzf tph.tar.gz \
         && rm -rf tph.tar.gz \
         && cd terraform-provider-helm_linux_amd64 \
-        && mv terraform-provider-helm terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
         && chmod 0700 terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
         && mkdir -p /root/.terraform.d/plugins/ \
         && mv terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} /root/.terraform.d/plugins/


### PR DESCRIPTION
Use gpii-ops build of Terraform Helm provider, as it fixes issue with Terraform ignoring `FAILED` releases. See [GPII-3525 JIRA issue](https://issues.gpii.net/browse/GPII-3525), PR https://github.com/gpii-ops/terraform-provider-helm/pull/1 and issue description in upstream repo - https://github.com/terraform-providers/terraform-provider-helm/issues/159 for more details.

I'll also open PR against upstream and once (if) the changes make it there, we should use that. In the meantime the Helm provider has also been adopted as official TF provider, therefore we should move away from using the release from `mcuadros` repo and use official one once this happens.