### PR TITLE
Fix helm-initializer not being triggered

### DIFF
--- a/modules/helm-initializer/main.tf
+++ b/modules/helm-initializer/main.tf
@@ -32,7 +32,7 @@ data "template_file" "tiller_rbac" {
 # This introduces undesired behavior that tiller will be deployed twice,
 # as the trigger mechanism is not based on the state, but rather on the change
 # of the state. So:
-# - 1st run: resource does not exist, the trigger is evaluated to "" (empty)
+# - 1st run: resource does not exist, the trigger is evaluated to random number
 #   -> resource is created
 # - 2nd run: resource does exist, but the trigger changed to "1" -> resource
 #   is recreated
@@ -44,7 +44,7 @@ data "external" "tiller_status" {
   program = [
     "bash",
     "-c",
-    "REPLICAS=$$(kubectl get deploy tiller-deploy -n ${var.tiller_namespace} -o jsonpath='{.status.readyReplicas}'); jq -n --arg replicas \"$$REPLICAS\" '{readyReplicas:$$replicas}'",
+    "REPLICAS=$$(kubectl get deploy tiller-deploy -n ${var.tiller_namespace} -o jsonpath='{.status.readyReplicas}'); [ \"$$REPLIAS\" != \"1\" ] && REPLICAS=\"$$RANDOM\"; jq -n --arg replicas \"$$REPLICAS\" '{readyReplicas:$$replicas}'",
   ]
 }
 


### PR DESCRIPTION
When there are 2 successive runs when a cluster is (re-)created and then re-created again immediately, `tiller_status` was evaluated as empty and would not re-trigger helm-initialized deployment. Changing the "negative", tiller-not-installed, value to a random number will make sure the value is different each time and tiller will be redeployed when needed.