### PR TITLE
Add google-beta provider to terraform-plugins

### DIFF
--- a/terraform-plugins/providers.tf
+++ b/terraform-plugins/providers.tf
@@ -4,6 +4,10 @@ provider "google" {
   version = "~> 1.16"
 }
 
+provider "google-beta" {
+  version = "~> 1.19"
+}
+
 provider "random" {
   version = "~> 1.3"
 }


### PR DESCRIPTION
Looks like `google-beta` provider was introduced in #27, but has not been added to the plugin list:
https://gitlab.com/gpii-ops/gpii-infra/-/jobs/134135946
```
Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
- Downloading plugin for provider "google-beta" (1.19.0)...
```