### PR TITLE
Do not activate-service-account in gke-cluster module in case SA key is missing

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -204,7 +204,7 @@ resource "google_container_cluster" "cluster-regional" {
 
   provisioner "local-exec" {
     command = <<EOF
-gcloud auth activate-service-account --key-file ${var.serviceaccount_key} \
+if [ "${var.serviceaccount_key}" != "" ] && [ -f ${var.serviceaccount_key} ]; then gcloud auth activate-service-account --key-file ${var.serviceaccount_key}; fi \
 && gcloud container clusters get-credentials ${var.cluster_name} \
 --region ${var.region} \
 --project ${var.project_id} \


### PR DESCRIPTION
Since we do not have SA key when app-default credentials is being used, this is needed. 
I am not sure how I skipped this one, I definitely tried cluster recreation with app-default credentials.