### PR TITLE
 [GPII-3326]: Make adding audit config in gcp-secret-mgmt module configurable

### DIFF
--- a/modules/gcp-secret-mgmt/main.tf
+++ b/modules/gcp-secret-mgmt/main.tf
@@ -20,6 +20,7 @@ provider "google" {
 # ------------------------------------------------------------------------------
 
 resource "null_resource" "add_audit_config" {
+  count = "${var.apply_audit_config ? 1 : 0}"
   provisioner "local-exec" {
     command    = "bash ${path.module}/scripts/add-audit-config"
     on_failure = "continue"

--- a/modules/gcp-secret-mgmt/main.tf
+++ b/modules/gcp-secret-mgmt/main.tf
@@ -21,6 +21,7 @@ provider "google" {
 
 resource "null_resource" "add_audit_config" {
   count = "${var.apply_audit_config ? 1 : 0}"
+
   provisioner "local-exec" {
     command    = "bash ${path.module}/scripts/add-audit-config"
     on_failure = "continue"

--- a/modules/gcp-secret-mgmt/variables.tf
+++ b/modules/gcp-secret-mgmt/variables.tf
@@ -29,6 +29,6 @@ variable "encryption_keys" {
 }
 
 variable "apply_audit_config" {
-  description = "Set this to true if you want to modify current project's IAM policy to have audit config provided by scripts/add-audit-config"
-  default     = false
+  description = "Set this to false if you don't want to modify current project's IAM policy to apply audit config provided by scripts/add-audit-config"
+  default     = true
 }

--- a/modules/gcp-secret-mgmt/variables.tf
+++ b/modules/gcp-secret-mgmt/variables.tf
@@ -30,5 +30,5 @@ variable "encryption_keys" {
 
 variable "apply_audit_config" {
   description = "Set this to true if you want to modify current project's IAM policy to have audit config provided by scripts/add-audit-config"
-  default = false
+  default     = false
 }

--- a/modules/gcp-secret-mgmt/variables.tf
+++ b/modules/gcp-secret-mgmt/variables.tf
@@ -27,3 +27,8 @@ variable "encryption_keys" {
 
   default = []
 }
+
+variable "apply_audit_config" {
+  description = "Set this to true if you want to modify current project's IAM policy to have audit config provided by scripts/add-audit-config"
+  default = false
+}


### PR DESCRIPTION
Required by https://github.com/gpii-ops/gpii-infra/pull/246.