### PR TITLE
Remove GCP SDK backup folder

### DIFF
--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -72,7 +72,8 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
         && gcloud --version \
         && gcloud components install alpha beta \
         && gcloud components update \
-        && gcloud config set component_manager/disable_update_check true
+        && gcloud config set component_manager/disable_update_check true \
+        && rm -rf /google-cloud-sdk/.install/.backup
 
 RUN curl -L -o kubectl \
         https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \


### PR DESCRIPTION
@amatas Discovered this today, helps to save ~200MB.

Before:
```
gpii/exekube        0.4.0-google        e0f9519dec8b        17 hours ago        1.18GB
```

After:
```
gpii/exekube        0.4.0-google        08cdef03c26e        14 seconds ago      994MB
```

