### PR TITLE
[GPII-3697]: Remove additional_zones from cluster-regional

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -134,8 +134,6 @@ resource "google_container_cluster" "cluster-regional" {
   name     = "${var.cluster_name}"
   region   = "${var.region}"
 
-  additional_zones = "${var.additional_zones}"
-
   initial_node_count      = "${var.initial_node_count}"
   node_version            = "${var.kubernetes_version}"
   min_master_version      = "${var.kubernetes_version}"

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -33,7 +33,8 @@ variable "region" {
 }
 
 variable "additional_zones" {
-  default = []
+  description = "Specify zones in which to spin up worker nodes (only if region is not set)"
+  default     = []
 }
 
 variable "enable_kubernetes_alpha" {


### PR DESCRIPTION
When `additional_zones` left blank, it causes issues for regional clusters:

```
module.gke_cluster.google_container_cluster.cluster-regional: Modifying... (ID: k8s-cluster)
  additional_zones.#:          "3" => "0"
  additional_zones.1988413740: "us-east1-d" => ""
  additional_zones.551448234:  "us-east1-b" => ""
  additional_zones.969236459:  "us-east1-c" => ""

Error: Error applying plan:

1 error(s) occurred:

* module.gke_cluster.google_container_cluster.cluster-regional: 1 error(s) occurred:

* google_container_cluster.cluster-regional: googleapi: Error 400: Must specify a field to update., badRequest
```