### PR TITLE
Only build master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,8 @@ build:
   stage: build
   script:
     - docker-compose build google
+  only:
+    - master@gpii-ops/exekube
 
 push:
   stage: push


### PR DESCRIPTION
`publish` was disabled for non-master branches, but that doesn't matter so much when this project and gpii-infra are built on the same CI worker (: