### PR TITLE
GPII-3715: Update Google provider to v2

### DIFF
--- a/terraform-plugins/providers.tf
+++ b/terraform-plugins/providers.tf
@@ -1,11 +1,11 @@
 # This is the list of Terraform plugins to be installed in the exekube container
 
 provider "google" {
-  version = "~> 1.20.0"
+  version = "~> 2.0.0"
 }
 
 provider "google-beta" {
-  version = "~> 1.20.0"
+  version = "~> 2.0.0"
 }
 
 provider "random" {


### PR DESCRIPTION
This updates Google provider to v2, and is prereq. to https://github.com/gpii-ops/gpii-infra/pull/299 as there are some changes required (see https://www.terraform.io/docs/providers/google/version_2_upgrade.html for details).