### PR TITLE
GPII-3763: Update Google provider to 2.1

### DIFF
--- a/terraform-plugins/providers.tf
+++ b/terraform-plugins/providers.tf
@@ -1,11 +1,11 @@
 # This is the list of Terraform plugins to be installed in the exekube container
 
 provider "google" {
-  version = "~> 2.0.0"
+  version = "~> 2.1.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.0.0"
+  version = "~> 2.1.0"
 }
 
 provider "random" {


### PR DESCRIPTION
PR updates google providers to 2.1. 

This should resolve the issue with stale clusters left behind when the cluster creation fails because of GCP resource exhaustion in given zone/region (see https://github.com/GoogleCloudPlatform/magic-modules/pull/1381 for more details).