### PR TITLE
 GPII-3419: Remove default GKE Cluster Node Pool

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -32,6 +32,8 @@ resource "null_resource" "region_or_zone" {
   "ERROR: Only one of region and main_compute_zone may be set." = true
 }
 
+data "google_compute_default_service_account" "default" {}
+
 resource "google_container_cluster" "cluster" {
   provider = "google-beta"
   count    = "${var.region == "" ? 1 : 0}"

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -42,8 +42,9 @@ resource "google_container_cluster" "cluster" {
 
   additional_zones = "${var.additional_zones}"
 
-  initial_node_count      = "${var.initial_node_count}"
-  node_version            = "${var.kubernetes_version}"
+  remove_default_node_pool = true
+  initial_node_count       = "${var.initial_node_count}"
+
   min_master_version      = "${var.kubernetes_version}"
   enable_kubernetes_alpha = "${var.enable_kubernetes_alpha}"
   enable_legacy_abac      = "false"
@@ -84,18 +85,6 @@ resource "google_container_cluster" "cluster" {
   maintenance_policy {
     daily_maintenance_window {
       start_time = "03:00"
-    }
-  }
-
-  node_config {
-    machine_type = "${var.node_type}"
-    disk_size_gb = 200
-    oauth_scopes = "${var.oauth_scopes}"
-    image_type   = "${var.node_image_type}"
-
-    labels {
-      project = "${var.project_id}"
-      pool    = "default"
     }
   }
 
@@ -141,8 +130,9 @@ resource "google_container_cluster" "cluster-regional" {
   name     = "${var.cluster_name}"
   region   = "${var.region}"
 
-  initial_node_count      = "${var.initial_node_count}"
-  node_version            = "${var.kubernetes_version}"
+  remove_default_node_pool = true
+  initial_node_count       = "${var.initial_node_count}"
+
   min_master_version      = "${var.kubernetes_version}"
   enable_kubernetes_alpha = "${var.enable_kubernetes_alpha}"
   enable_legacy_abac      = "false"
@@ -183,18 +173,6 @@ resource "google_container_cluster" "cluster-regional" {
   maintenance_policy {
     daily_maintenance_window {
       start_time = "03:00"
-    }
-  }
-
-  node_config {
-    machine_type = "${var.node_type}"
-    disk_size_gb = 200
-    oauth_scopes = "${var.oauth_scopes}"
-    image_type   = "${var.node_image_type}"
-
-    labels {
-      project = "${var.project_id}"
-      pool    = "default"
     }
   }
 

--- a/modules/gke-cluster/node_pool.tf
+++ b/modules/gke-cluster/node_pool.tf
@@ -1,0 +1,99 @@
+resource "google_container_node_pool" "primary" {
+  provider = "google-beta"
+  count    = "${var.region == "" ? 1 : 0}"
+
+  project = "${var.project_id}"
+  cluster = "${google_container_cluster.cluster.name}"
+  zone    = "${var.main_compute_zone}"
+
+  autoscaling {
+    min_node_count = "${var.primary_pool_min_node_count}"
+    max_node_count = "${var.primary_pool_max_node_count}"
+  }
+
+  initial_node_count = "${var.primary_pool_initial_node_count}"
+
+  management {
+    auto_repair  = "${var.primary_pool_auto_repair}"
+    auto_upgrade = "${var.primary_pool_auto_upgrade}"
+  }
+
+  node_config {
+    disk_size_gb    = "${var.primary_pool_disk_size_gb}"
+    disk_type       = "${var.primary_pool_disk_type}"
+    machine_type    = "${var.primary_pool_machine_type}"
+    image_type      = "${var.primary_pool_image_type}"
+    oauth_scopes    = "${var.primary_pool_oauth_scopes}"
+    service_account = "${var.primary_pool_service_account != "" ? var.primary_pool_service_account : data.google_compute_default_service_account.default.email }"
+
+    labels {
+      project = "${var.project_id}"
+      cluster = "${google_container_cluster.cluster.name}"
+      pool    = "primary"
+    }
+
+    workload_metadata_config {
+      node_metadata = "SECURE"
+    }
+  }
+
+  timeouts {
+    create = "${var.node_pool_create_timeout}"
+    update = "${var.node_pool_update_timeout}"
+    delete = "${var.node_pool_delete_timeout}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_container_node_pool" "primary-regional" {
+  provider = "google-beta"
+  count    = "${var.region == "" ? 0 : 1}"
+
+  project = "${var.project_id}"
+  cluster = "${google_container_cluster.cluster-regional.name}"
+  region  = "${var.region}"
+
+  autoscaling {
+    min_node_count = "${var.primary_pool_min_node_count}"
+    max_node_count = "${var.primary_pool_max_node_count}"
+  }
+
+  initial_node_count = "${var.primary_pool_initial_node_count}"
+
+  management {
+    auto_repair  = "${var.primary_pool_auto_repair}"
+    auto_upgrade = "${var.primary_pool_auto_upgrade}"
+  }
+
+  node_config {
+    disk_size_gb    = "${var.primary_pool_disk_size_gb}"
+    disk_type       = "${var.primary_pool_disk_type}"
+    machine_type    = "${var.primary_pool_machine_type}"
+    image_type      = "${var.primary_pool_image_type}"
+    oauth_scopes    = "${var.primary_pool_oauth_scopes}"
+    service_account = "${var.primary_pool_service_account != "" ? var.primary_pool_service_account : data.google_compute_default_service_account.default.email }"
+
+    labels {
+      project = "${var.project_id}"
+      cluster = "${google_container_cluster.cluster-regional.name}"
+      pool    = "primary"
+    }
+
+    workload_metadata_config {
+      node_metadata = "SECURE"
+    }
+  }
+
+  timeouts {
+    create = "${var.node_pool_create_timeout}"
+    update = "${var.node_pool_update_timeout}"
+    delete = "${var.node_pool_delete_timeout}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -117,3 +117,73 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
   description = "Set auth mechanism for Istio add-on"
 }
+
+variable "primary_pool_min_node_count" {
+  default     = 1
+  description = "Primary Node pool Min node count"
+}
+
+variable "primary_pool_max_node_count" {
+  default     = 1
+  description = "Primary Node pool Max node count"
+}
+
+variable "primary_pool_initial_node_count" {
+  default     = 1
+  description = "Primary Node pool Initial node count"
+}
+
+variable "primary_pool_auto_repair" {
+  default     = true
+  description = "Primary Node pool Auto repair enabled"
+}
+
+variable "primary_pool_auto_upgrade" {
+  default     = true
+  description = "Primary Node pool Auto upgrade enabled"
+}
+
+variable "primary_pool_disk_size_gb" {
+  default     = 200
+  description = "Primary Node pool Disk size in GB"
+}
+
+variable "primary_pool_disk_type" {
+  default     = "pd-standard"
+  description = "Primary Node pool Disk type"
+}
+
+variable "primary_pool_machine_type" {
+  default     = "n1-standard-2"
+  description = "Primary Node pool Machine type"
+}
+
+variable "primary_pool_image_type" {
+  default     = "COS"
+  description = "Primary Node pool Image type"
+}
+
+variable "primary_pool_oauth_scopes" {
+  default     = ["gke-default"]
+  description = "Primary Node pool OAuth scopes"
+}
+
+variable "primary_pool_service_account" {
+  default     = ""
+  description = "Primary Node pool Service account"
+}
+
+variable "node_pool_create_timeout" {
+  default     = "30m"
+  description = "Node pool Create timeout"
+}
+
+variable "node_pool_update_timeout" {
+  default     = "30m"
+  description = "Node pool Update timeout"
+}
+
+variable "node_pool_delete_timeout" {
+  default     = "30m"
+  description = "Node pool Delete timeout"
+}

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -41,31 +41,12 @@ variable "enable_kubernetes_alpha" {
   default = "false"
 }
 
-variable "oauth_scopes" {
-  type = "list"
-
-  default = [
-    "https://www.googleapis.com/auth/compute",
-    "https://www.googleapis.com/auth/devstorage.read_only",
-    "https://www.googleapis.com/auth/logging.write",
-    "https://www.googleapis.com/auth/monitoring",
-  ]
-}
-
-variable "node_type" {
-  default = "n1-standard-2"
-}
-
-variable "node_image_type" {
-  default = "COS"
-}
-
 variable "initial_node_count" {
-  default = 2
+  default = 1
 }
 
 variable "kubernetes_version" {
-  default = "1.10.5-gke.0"
+  default = "1.12.5-gke.10"
 }
 
 variable "monitoring_service" {


### PR DESCRIPTION
This is 1st part of moving over to Node Pools to manage nodes of GKE Clusters

It's part of the story described in gpii-ops/gpii-infra#327

**This PR**:
- Removes default GKE Cluster Node Pool

This is a breaking change, but splitting (together with #47) allows for no-downtime migration process (create new node pool, drain old nodes, delete default node pool). 

This PR should be merged only after #47 and gpii-ops/gpii-infra#327. See gpii-ops/gpii-infra#327 for more details.