### PR TITLE
GPII-3940: Upgrade terrafrom and providers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.5.1-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.6.0-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -L -o kubectl \
         && chmod 0700 kubectl \
         && mv kubectl /usr/bin
 
-ENV HELM_VERSION 2.14.0
+ENV HELM_VERSION 2.13.1
 RUN curl -L -o helm.tar.gz \
         https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
         && tar -xvzf helm.tar.gz \

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -56,7 +56,7 @@ RUN apk --no-cache add \
         make \
         ruby-dev
 
-ENV CLOUD_SDK_VERSION 242.0.0
+ENV CLOUD_SDK_VERSION 247.0.0
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
         && tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
@@ -71,13 +71,13 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
         && gcloud config set component_manager/disable_update_check true \
         && rm -rf /google-cloud-sdk/.install/.backup
 
-ENV KUBECTL_VERSION 1.12.7
+ENV KUBECTL_VERSION 1.12.8
 RUN curl -L -o kubectl \
         https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
         && chmod 0700 kubectl \
         && mv kubectl /usr/bin
 
-ENV HELM_VERSION 2.13.1
+ENV HELM_VERSION 2.14.0
 RUN curl -L -o helm.tar.gz \
         https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
         && tar -xvzf helm.tar.gz \
@@ -85,27 +85,17 @@ RUN curl -L -o helm.tar.gz \
         && chmod 0700 linux-amd64/helm \
         && mv linux-amd64/helm /usr/bin
 
-ENV TERRAFORM_VERSION 0.11.12
+ENV TERRAFORM_VERSION 0.11.14
 RUN curl -o ./terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
         && unzip terraform.zip \
         && mv terraform /usr/bin \
         && rm -rf terraform.zip
 
-ENV TERRAGRUNT_VERSION 0.18.3
+ENV TERRAGRUNT_VERSION 0.18.6
 RUN curl -L -o ./terragrunt \
         https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 \
         && chmod 0700 terragrunt \
         && mv terragrunt /usr/bin
-
-ENV TERRAFORM_PROVIDER_HELM_VERSION 0.7.0
-RUN curl -L -o ./tph.tar.gz \
-        https://github.com/gpii-ops/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
-        && tar -xvzf tph.tar.gz \
-        && rm -rf tph.tar.gz \
-        && cd terraform-provider-helm_linux_amd64 \
-        && chmod 0700 terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
-        && mkdir -p /root/.terraform.d/plugins/ \
-        && mv terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} /root/.terraform.d/plugins/
 
 ENV HELMFILE_VERSION 0.54.2
 RUN curl -L -o helmfile \
@@ -118,6 +108,7 @@ COPY terraform-plugins /terraform-plugins/
 RUN cd /terraform-plugins \
     && terraform init \
     && find /terraform-plugins \
+    && mkdir -p /root/.terraform.d/plugins \
     && cp /terraform-plugins/.terraform/plugins/linux_amd64/terraform-provider* /root/.terraform.d/plugins/ \
     && cd \
     && rm -fr /terraform-plugins

--- a/terraform-plugins/providers.tf
+++ b/terraform-plugins/providers.tf
@@ -1,41 +1,45 @@
 # This is the list of Terraform plugins to be installed in the exekube container
 
 provider "google" {
-  version = "~> 2.1.0"
+  version = "~> 2.7.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.1.0"
+  version = "~> 2.7.0"
 }
 
 provider "random" {
-  version = "~> 2.0.0"
+  version = "~> 2.1.2"
 }
 
 provider "null" {
-  version = "~> 1.0.0"
+  version = "~> 2.1.2"
 }
 
 provider "kubernetes" {
-  version = "~> 1.4.0"
+  version = "~> 1.6.2"
 }
 
 provider "template" {
-  version = "~> 1.0.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {
-  version = "~> 1.2.0"
+  version = "~> 2.0.1"
 }
 
 provider "local" {
-  version = "~> 1.1.0"
+  version = "~> 1.2.2"
 }
 
 provider "external" {
-  version = "~> 1.0.0"
+  version = "~> 1.1.2"
 }
 
 provider "aws" {
-  version = "~> 1.52.0"
+  version = "~> 2.11.0"
+}
+
+provider "helm" {
+  version = "~> 0.9.1"
 }


### PR DESCRIPTION
This PR:
- updates Terraform
- updates Google Cloud SDK
- updates kubectl
- ~updates Helm~
- updates Terragrunt
- updates all Terraform providers to the latest
- moves to vanilla Helm provider, as the changes we needed have been merged upstream

This mainly fixes node_pool recreation due to metadata config - see https://github.com/GoogleCloudPlatform/magic-modules/pull/1507 for details.

Update:
Helm update was reverted due to an issue with spec validation (see https://github.com/helm/helm/issues/5750). This should be fixed in soon to be 0.14.1, but it was not available at the time of this PR yet.

This should be tagged as `0.6.0-google_gpii.0` once merged.

Also:
- I've tried to upgrade to Alpine 3.9, but failed due to issue with compiling grpc with newer gcc version (see https://github.com/grpc/grpc/pull/15532), ticket has been created to pick this up: [GPII-3947
Upgrade exekube to latest Alpine](https://issues.gpii.net/browse/GPII-3947)
- We don't scan exekube image atm, a ticket for that has been created as well - [GPII-3946
Scan exekube docker image for vulnerabilities](https://issues.gpii.net/browse/GPII-3946)
- Google provider now prefers to use `location` field for GKE clusters and node-pools, the old `zone` and `region` have been deprecated (see https://www.terraform.io/docs/providers/google/r/container_cluster.html#location). We should abandon the deprecated fields in favor of `location`, this will also allow us to get rid of the 2 resources split for regional/zonal clusters in `gke-cluster` module. Ticket created - [GPII-3949
Use `location` in cluster and node_pool resources in `gke-cluster` exekube module](https://issues.gpii.net/browse/GPII-3949)

Upstream PR has been opened - https://github.com/exekube/exekube/pull/124.