### PR TITLE
[GPII-3868]: Enable legacy metadata endpoints for node pools

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.7.0-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.8.0-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/node_pool.tf
+++ b/modules/gke-cluster/node_pool.tf
@@ -35,6 +35,10 @@ resource "google_container_node_pool" "primary" {
     workload_metadata_config {
       node_metadata = "SECURE"
     }
+
+    metadata = {
+      disable-legacy-endpoints = "false"
+    }
   }
 
   timeouts {
@@ -84,6 +88,10 @@ resource "google_container_node_pool" "primary-regional" {
 
     workload_metadata_config {
       node_metadata = "SECURE"
+    }
+
+    metadata = {
+      disable-legacy-endpoints = "false"
     }
   }
 


### PR DESCRIPTION
Consumed by https://github.com/gpii-ops/gpii-infra/pull/430.