### PR TITLE
Disable l7 load balancer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.7.0-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.7.1-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -67,7 +67,7 @@ resource "google_container_cluster" "cluster" {
     }
 
     http_load_balancing {
-      disabled = false
+      disabled = "${var.http_load_balancing_disabled}"
     }
 
     network_policy_config {

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -66,6 +66,11 @@ variable "dashboard_disabled" {
   description = "Disable Kubernetes Dashboard"
 }
 
+variable "http_load_balancing_disabled" {
+  default     = false
+  description = "Disable GKE HTTP (L7) load balancing controller addon"
+}
+
 variable "master_auth_username" {
   default     = ""
   description = "The username to use for HTTP basic authentication (setting both password and username to empty strings disables legacy basic authentication)"


### PR DESCRIPTION
This PR adds support for disabling GKE HTTP (L7) load balancing controller addon, as it's not being used.

Should be tagged as `0.7.1-google_gpii.0` once merged. PR will be opened against upstream once this is reviewed & merged.