### PR TITLE
Fix gke-network module output when glopal_ip is disabled

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.7.1-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.7.2-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-network/outputs.tf
+++ b/modules/gke-network/outputs.tf
@@ -1,5 +1,5 @@
 output "static_ip_address" {
-  value = "${google_compute_address.ingress_controller_ip.0.address}"
+  value = "${element(concat(google_compute_address.ingress_controller_ip.*.address, list("")), 0)}"
 }
 
 output "dns_zones" {


### PR DESCRIPTION
This PR fixes the output of `gke-network` module when `create_static_ip_address` is set to `false`.

Current error:
```yaml
Error: Error applying plan:

1 error occurred:
        * module.gke_network.output.static_ip_address: Resource 'google_compute_address.ingress_controller_ip.0' does not have attribute 'address' for variable 'google_compute_address.ingress_controller_ip.0.address'
```

Should be tagged as `0.7.2-google_gpii.0` once merged. PR will be opened against upstream once this is reviewed & merged.