### PR TITLE
Update kubectl to 1.13

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.8.0-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.0-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -71,7 +71,7 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
         && gcloud config set component_manager/disable_update_check true \
         && rm -rf /google-cloud-sdk/.install/.backup
 
-ENV KUBECTL_VERSION 1.12.8
+ENV KUBECTL_VERSION 1.13.8
 RUN curl -L -o kubectl \
         https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
         && chmod 0700 kubectl \


### PR DESCRIPTION
This PR updates `kubectl` version to `1.13.8`. Main reason being that 1.13 has the option `--address` available for `port-forward` command, which is required for my work on enabling the access to CouchDB UI ([GPII-4023](https://issues.gpii.net/browse/GPII-4023)).

Once merged, new tag `0.9.0-google_gpii.0` should be created.

PR against upstream will be opened and linked, once this PR is past review.

~@mrtyler I was thinking about merging this PR together with #62, as both are trying to increase minor version, but if that doesn't sound ok I'm happy to bump this to `0.8.1` or `0.9` even.~