### PR TITLE
Remove helm init from gke-cluster

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.0-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.1-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -113,8 +113,7 @@ gcloud auth activate-service-account --key-file ${var.serviceaccount_key} \
 && kubectl create clusterrolebinding \
 creator-cluster-admin-binding \
 --clusterrole=cluster-admin \
---user=$(gcloud info --format='value(config.account)') \
-&& helm init --client-only
+--user=$(gcloud info --format='value(config.account)')
 EOF
   }
 
@@ -202,8 +201,7 @@ if [ "${var.serviceaccount_key}" != "" ] && [ -f ${var.serviceaccount_key} ]; th
 && kubectl create clusterrolebinding \
 creator-cluster-admin-binding \
 --clusterrole=cluster-admin \
---user=$(gcloud info --format='value(config.account)') \
-&& helm init --client-only
+--user=$(gcloud info --format='value(config.account)')
 EOF
   }
 


### PR DESCRIPTION
I am not sure what was the original intent for this, blame points me to these two commits:
https://github.com/exekube/exekube/commit/14987c5f61bc806356701b994cb8aafc10c00b5b
https://github.com/exekube/exekube/commit/bedea97bfdaf3d251880f70441698d8d2756685f

But description is not helpful to understand the reason.

Anyway, there is no need to touch helm in `gke-cluster`, since there is a separate `helm-initializer` module, and this also breaks things when Helm env vars are set (https://github.com/gpii-ops/gpii-infra/pull/461).