### PR TITLE
GPII-4061: Remove duplicate firewall rules

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.2-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.3-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-network/main.tf
+++ b/modules/gke-network/main.tf
@@ -28,6 +28,8 @@ resource "google_compute_subnetwork" "subnets" {
 
 # Discard the default network as we don't need it
 resource "null_resource" "delete_default_network" {
+  count = "${var.delete_default_network ? 1 : 0}"
+
   provisioner "local-exec" {
     command = <<EOF
 gcloud --project $TF_VAR_project_id --quiet compute firewall-rules delete \

--- a/modules/gke-network/main.tf
+++ b/modules/gke-network/main.tf
@@ -26,63 +26,6 @@ resource "google_compute_subnetwork" "subnets" {
   ]
 }
 
-# Firewall rules for GKE nodes
-resource "google_compute_firewall" "allow_nodes_internal" {
-  name        = "allow-nodes-internal"
-  description = "Allow traffic between nodes"
-
-  network  = "${google_compute_network.network.self_link}"
-  priority = "65534"
-
-  direction     = "INGRESS"
-  source_ranges = ["${google_compute_subnetwork.subnets.*.ip_cidr_range}"]
-
-  allow {
-    protocol = "icmp"
-  }
-
-  allow {
-    protocol = "tcp"
-    ports    = ["0-65535"]
-  }
-
-  allow {
-    protocol = "udp"
-    ports    = ["0-65535"]
-  }
-}
-
-# Firewall rules for GKE pods
-resource "google_compute_firewall" "allow_pods_internal" {
-  name     = "allow-pods-internal"
-  network  = "${google_compute_network.network.name}"
-  priority = "1000"
-
-  description = "Allow traffic between pods and services"
-
-  # services and pods ranges
-  direction = "INGRESS"
-
-  source_ranges = [
-    "${google_compute_subnetwork.subnets.*.secondary_ip_range.0.ip_cidr_range}",
-    "${google_compute_subnetwork.subnets.*.secondary_ip_range.1.ip_cidr_range}",
-  ]
-
-  allow {
-    protocol = "icmp"
-  }
-
-  allow {
-    protocol = "tcp"
-    ports    = ["0-65535"]
-  }
-
-  allow {
-    protocol = "udp"
-    ports    = ["0-65535"]
-  }
-}
-
 # Discard the default network as we don't need it
 resource "null_resource" "delete_default_network" {
   provisioner "local-exec" {

--- a/modules/gke-network/variables.tf
+++ b/modules/gke-network/variables.tf
@@ -16,6 +16,10 @@ variable "create_static_ip_address" {
   default = true
 }
 
+variable "delete_default_network" {
+  default = true
+}
+
 variable "static_ip_region" {
   default = "europe-north1"
 }


### PR DESCRIPTION
This PR:
- Removes duplicated firewall rules ([GPII-4061](https://issues.gpii.net/browse/GPII-4061)). GKE creates required rules on its own and these are less open and use target tags.
- Makes `delete_default_network` optional - Terraform has native functionality to do this

<img width="1169" alt="Screenshot 2019-08-07 at 13 55 14" src="https://user-images.githubusercontent.com/3027227/62624723-9d8c8b80-b91b-11e9-95da-1de11abd3c0c.png">

New tag `0.9.3-google_gpii.0` will be created once this PR is reviewed and merged, as well as upstream PR.