### PR TITLE
[GPII-4057]: Lock gem versions with bundler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !cli/
 !modules/
 !terraform-plugins/
+!gemfiles/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.3-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.4-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.2-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.3-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -50,8 +50,8 @@ RUN apk --no-cache add \
         g++ \
         make \
         ruby-dev \
-    && gem install --no-ri --no-rdoc bundler rake \
-    && bundle install \
+    && gem install --no-ri --no-rdoc bundler:2.0.2 rake:12.3.3 \
+    && bundle install --no-cache --frozen --without test \
     && apk del \
         g++ \
         make \

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -49,10 +49,10 @@ ENV BUNDLE_GEMFILE /gemfiles/google/Gemfile
 RUN apk --no-cache add \
         g++ \
         make \
-        ruby-dev && \
-    gem install --no-ri --no-rdoc bundler rake && \
-    bundle install && \
-    apk del \
+        ruby-dev \
+    && gem install --no-ri --no-rdoc bundler rake \
+    && bundle install \
+    && apk del \
         g++ \
         make \
         ruby-dev

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -43,14 +43,15 @@ RUN apk --no-cache add \
         ruby \
         ruby-json
 
-ENV GOOGLE_CLOUD_MONITORING_VERSION 0.29.2
-ENV GOOGLE_CLOUD_LOGGING_VERSION 1.5.7
+COPY gemfiles/google /gemfiles/google/
+ENV BUNDLE_GEMFILE /gemfiles/google/Gemfile
+
 RUN apk --no-cache add \
         g++ \
         make \
         ruby-dev && \
-    gem install --no-ri google-protobuf:3.6.1 etc grpc --platform=ruby && \
-    gem install --no-ri --no-rdoc rake google-cloud-monitoring:${GOOGLE_CLOUD_MONITORING_VERSION} google-cloud-logging:${GOOGLE_CLOUD_LOGGING_VERSION} && \
+    gem install --no-ri --no-rdoc bundler rake && \
+    bundle install && \
     apk del \
         g++ \
         make \

--- a/gemfiles/google/Gemfile
+++ b/gemfiles/google/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'google-cloud-monitoring', '~> 0.30.0'
+gem 'google-cloud-logging', '~> 1.6.6'
+gem 'grpc'
+gem 'etc'

--- a/gemfiles/google/Gemfile
+++ b/gemfiles/google/Gemfile
@@ -4,3 +4,4 @@ gem 'google-cloud-monitoring', '~> 0.30.0'
 gem 'google-cloud-logging', '~> 1.6.6'
 gem 'grpc'
 gem 'etc'
+gem 'rspec', :group => :test

--- a/gemfiles/google/Gemfile.lock
+++ b/gemfiles/google/Gemfile.lock
@@ -1,0 +1,71 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    concurrent-ruby (1.1.5)
+    etc (1.0.1)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-cloud-core (1.3.0)
+      google-cloud-env (~> 1.0)
+    google-cloud-env (1.2.0)
+      faraday (~> 0.11)
+    google-cloud-logging (1.6.6)
+      concurrent-ruby (~> 1.1)
+      google-cloud-core (~> 1.2)
+      google-gax (~> 1.7)
+      googleapis-common-protos-types (>= 1.0.2)
+      stackdriver-core (~> 1.3)
+    google-cloud-monitoring (0.30.0)
+      google-gax (~> 1.7)
+      googleapis-common-protos-types (>= 1.0.2)
+    google-gax (1.7.0)
+      google-protobuf (~> 3.2)
+      googleapis-common-protos (>= 1.3.5, < 2.0)
+      googleauth (>= 0.6.2, < 0.10.0)
+      grpc (>= 1.7.2, < 2.0)
+      rly (~> 0.2.3)
+    google-protobuf (3.9.1)
+    googleapis-common-protos (1.3.9)
+      google-protobuf (~> 3.0)
+      googleapis-common-protos-types (~> 1.0)
+      grpc (~> 1.0)
+    googleapis-common-protos-types (1.0.4)
+      google-protobuf (~> 3.0)
+    googleauth (0.9.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    grpc (1.22.0)
+      google-protobuf (~> 3.8)
+      googleapis-common-protos-types (~> 1.0)
+    jwt (2.2.1)
+    memoist (0.16.0)
+    multi_json (1.13.1)
+    multipart-post (2.1.1)
+    os (1.0.1)
+    public_suffix (3.1.1)
+    rly (0.2.3)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    stackdriver-core (1.3.3)
+      google-cloud-core (~> 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  etc
+  google-cloud-logging (~> 1.6.6)
+  google-cloud-monitoring (~> 0.30.0)
+  grpc
+
+BUNDLED WITH
+   2.0.2

--- a/gemfiles/google/Gemfile.lock
+++ b/gemfiles/google/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     concurrent-ruby (1.1.5)
+    diff-lcs (1.3)
     etc (1.0.1)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -50,6 +51,19 @@ GEM
     os (1.0.1)
     public_suffix (3.1.1)
     rly (0.2.3)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
     signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -66,6 +80,7 @@ DEPENDENCIES
   google-cloud-logging (~> 1.6.6)
   google-cloud-monitoring (~> 0.30.0)
   grpc
+  rspec
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
This is a follow-up on https://github.com/gpii-ops/gpii-infra/pull/472.
This also bumps Stackdriver gems to latest versions.