### PR TITLE
Add new Istio GCR registry to whitelist

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.4-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.5-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/bin_auth.tf
+++ b/modules/gke-cluster/bin_auth.tf
@@ -79,6 +79,9 @@ resource "google_binary_authorization_policy" "policy" {
     name_pattern = "gcr.io/istio-release/*"
   }
   admission_whitelist_patterns {
+    name_pattern = "gke.gcr.io/istio/*"
+  }
+  admission_whitelist_patterns {
     name_pattern = "gcr.io/projectcalico-org/*"
   }
   admission_whitelist_patterns {


### PR DESCRIPTION
This PR whitelists GCR registry `gke.gcr.io/istio` used by GKE Istio 1.1 images.

Once merged, tag `0.9.5-google_gpii.0` should be created.