### PR TITLE
GPII-4110: Add missing istio/prometheus whitelist pattern for promsd …

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.5-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.6-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/bin_auth.tf
+++ b/modules/gke-cluster/bin_auth.tf
@@ -76,6 +76,9 @@ resource "google_binary_authorization_policy" "policy" {
     name_pattern = "gcr.io/gke-release/istio/*"
   }
   admission_whitelist_patterns {
+    name_pattern = "gcr.io/gke-release/istio/prometheus/*"
+  }
+  admission_whitelist_patterns {
     name_pattern = "gcr.io/istio-release/*"
   }
   admission_whitelist_patterns {


### PR DESCRIPTION
This PR whitelists GCR registry pattern `gcr.io/gke-release/istio/prometheus/*` used by GKE Istio promsd image and fixes [GPII-4110](https://issues.gpii.net/browse/GPII-4110).

Once merged, tag `0.9.6-google_gpii.0` should be created.