### PR TITLE
[GPII-3836]: Add configurable versioning setting for gcp-secret-mgmt GS bucket

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.6-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.7-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gcp-secret-mgmt/main.tf
+++ b/modules/gcp-secret-mgmt/main.tf
@@ -89,6 +89,10 @@ resource "google_storage_bucket" "gcs_buckets" {
   location      = "${var.storage_location}"
   force_destroy = true
 
+  versioning = {
+    enabled = "${var.bucket_versioning_enabled}"
+  }
+
   # We must specify the provider due to the workaround for
   # https://github.com/hashicorp/terraform/issues/13018#issuecomment-291547654
   provider = "google.google"

--- a/modules/gcp-secret-mgmt/variables.tf
+++ b/modules/gcp-secret-mgmt/variables.tf
@@ -28,11 +28,15 @@ variable "storage_location" {
 
 variable "encryption_keys" {
   description = "Names of encryption keys to create (a storage bucket will also be created for each)"
-
   default = []
 }
 
 variable "apply_audit_config" {
   description = "Set this to false if you don't want to modify current project's IAM policy to apply audit config provided by scripts/add-audit-config"
   default     = true
+}
+
+variable "bucket_versioning_enabled" {
+  description = "Set this to true to enable versioning for GS bucket that stores encrypted secrets"
+	default     = false
 }

--- a/modules/gcp-secret-mgmt/variables.tf
+++ b/modules/gcp-secret-mgmt/variables.tf
@@ -38,5 +38,5 @@ variable "apply_audit_config" {
 
 variable "bucket_versioning_enabled" {
   description = "Set this to true to enable versioning for GS bucket that stores encrypted secrets"
-	default     = false
+  default     = false
 }


### PR DESCRIPTION
This PR adds configurable versioning setting for gcp-secret-mgmt GS bucket.