### PR TITLE
GPII-4221: Add ncurses for colored output

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.7-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.8-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -41,7 +41,8 @@ RUN apk --no-cache add \
         jq \
         gnupg \
         ruby \
-        ruby-json
+        ruby-json \
+        ncurses
 
 COPY gemfiles/google /gemfiles/google/
 ENV BUNDLE_GEMFILE /gemfiles/google/Gemfile


### PR DESCRIPTION
This PR adds `ncurses` to support working with colors and other terminal functionality of `tput`.

The image should be tagged as `0.9.8-google-gpii.0` once PR is merged.