### PR TITLE
Fix missing gke gcr io

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.8-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.9-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/bin_auth.tf
+++ b/modules/gke-cluster/bin_auth.tf
@@ -115,6 +115,9 @@ resource "google_binary_authorization_policy" "policy" {
     name_pattern = "k8s.gcr.io/*"
   }
   admission_whitelist_patterns {
+    name_pattern = "gke.gcr.io/*"
+  }
+  admission_whitelist_patterns {
     name_pattern = "gcr.io/stackdriver-agents/*"
   }
 }


### PR DESCRIPTION
This PR adds missing `gke.grc.io` rule to the Bin-auth whitelisted images patterns and fixes one of the errors observed in [GPII-3850](https://issues.gpii.net/browse/GPII-3850).

```
Failed:
Create pod
kube-proxy-gke-k8s-cluster-terraform-20190319173-571935b8-99sf failed to be created
```

**Changes:**
- Add missing `gke.gcr.io` to bin-auth whitelist


Tag **`0.9.9-google_gpii.0`** shall be created once this PR is merged.