### PR TITLE
GPII-3850: Add missing gke.gcr.io/istio/prometheus/  to bin-auth whitelist

### DIFF
--- a/modules/gke-cluster/bin_auth.tf
+++ b/modules/gke-cluster/bin_auth.tf
@@ -85,6 +85,9 @@ resource "google_binary_authorization_policy" "policy" {
     name_pattern = "gke.gcr.io/istio/*"
   }
   admission_whitelist_patterns {
+    name_pattern = "gke.gcr.io/istio/prometheus/*"
+  }
+  admission_whitelist_patterns {
     name_pattern = "gcr.io/projectcalico-org/*"
   }
   admission_whitelist_patterns {


### PR DESCRIPTION
This PR adds missing `gke.grc.io/istio/prometheus/*` rule to the Bin-auth whitelisted images and
fixes the additional error observed, part of [GPII-3850](https://issues.gpii.net/browse/GPII-3850).

```
pods "promsd-76f8d4cff8-6jmsv" is forbidden: image policy webhook backend denied one or more images: Denied by default admission rule. Overridden by evaluation mode. Denied by default admission rule. Overridden by evaluation mode
```


**Changes:**
- Add missing `gke.gcr.io/istio/prometheus/*` to bin-auth whitelist


Tag **`0.9.10-google_gpii.0`** shall be created once this PR is merged.