### PR TITLE
[GPII-3718] Update Google Terraform providers and Google Cloud SDK

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -17,8 +17,8 @@ func main() {
 	app.Name = "Exekube"
 	app.Version = "0.5.0"
 	app.Usage = "Manage the whole lifecycle of Kubernetes-based projects as declarative code"
-	app.Authors = []cli.Author{
-		cli.Author{
+	app.Authors = []*cli.Author{
+		&cli.Author{
 			Name:  "Ilya Sotkov",
 			Email: "ilya@sotkov.com",
 		},
@@ -37,7 +37,7 @@ func main() {
 		return nil
 	}
 
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:    "apply",
 			Aliases: []string{},

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.9-google}
+    image: ${DOCKER_IMAGE:-exekube/exekube}:${CI_COMMIT_TAG:-0.9.10-google}
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -58,7 +58,7 @@ RUN apk --no-cache add \
         make \
         ruby-dev
 
-ENV CLOUD_SDK_VERSION 247.0.0
+ENV CLOUD_SDK_VERSION 275.0.0
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
         && tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \

--- a/terraform-plugins/providers.tf
+++ b/terraform-plugins/providers.tf
@@ -1,11 +1,11 @@
 # This is the list of Terraform plugins to be installed in the exekube container
 
 provider "google" {
-  version = "~> 2.7.0"
+  version = "~> 2.20.1"
 }
 
 provider "google-beta" {
-  version = "~> 2.7.0"
+  version = "~> 2.20.1"
 }
 
 provider "random" {


### PR DESCRIPTION
This PR updates the Google Terraform providers and the Google Cloud SDK with the hope of make more reliable every deployment process.

Tag **`0.9.11-google_gpii.0`** shall be created once this PR is merged.