### PR TITLE
Add support for access logs for stackdriver exports

### DIFF
--- a/modules/gcp-secret-mgmt/variables.tf
+++ b/modules/gcp-secret-mgmt/variables.tf
@@ -28,7 +28,7 @@ variable "storage_location" {
 
 variable "encryption_keys" {
   description = "Names of encryption keys to create (a storage bucket will also be created for each)"
-  default = []
+  default     = []
 }
 
 variable "apply_audit_config" {

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -36,6 +36,10 @@ resource "google_storage_bucket" "exported-logs" {
       age = "${var.exported_logs_expire_after}"
     }
   }
+
+  logging {
+    log_bucket = "${var.exported_logs_access_log_bucket}"
+  }
 }
 
 resource "google_storage_bucket" "exported-logs-custom-encryption" {
@@ -61,6 +65,10 @@ resource "google_storage_bucket" "exported-logs-custom-encryption" {
 
   encryption {
     default_kms_key_name = "${var.exported_logs_encryption_key}"
+  }
+
+  logging {
+    log_bucket = "${var.exported_logs_access_log_bucket}"
   }
 }
 

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -45,3 +45,8 @@ variable "exported_logs_encryption_key" {
   description = "Name of a KMS key to use (e.g. projects/my-project/locations/global/keyRings/keyring/cryptoKeys/gcp-stackdriver-export). Empty string means use Google's default encryption."
   default     = ""
 }
+
+variable "exported_logs_access_log_bucket" {
+  description = "Exported logs access log bucket name"
+  default     = ""
+}


### PR DESCRIPTION
This PR adds support for configuring access-logs for stackdriver export module.

**Changes:**
- Add support for access logs (`exported_logs_access_log_bucket) for `gcp-stackdriver-export/main.tf ` module

Tag **`0.9.12-google_gpii.0`** shall be created once this PR is merged.